### PR TITLE
Fix overwritten buffers in audio queue

### DIFF
--- a/audio_processing_queue.py
+++ b/audio_processing_queue.py
@@ -15,7 +15,12 @@ class AudioProcessingQueue:
         self.thread.start()
 
     def add_to_queue(self, indata, pan_speed, reverb_amount):
-        self.queue.put((indata, pan_speed, reverb_amount))
+        """Add a copy of the incoming data to the processing queue."""
+        # The buffer provided by ``sounddevice`` is reused after the callback
+        # returns.  If we store it directly, the data may be overwritten before
+        # it is processed.  Copy the array to ensure the queued data remains
+        # intact.
+        self.queue.put((indata.copy(), pan_speed, reverb_amount))
 
     def process_queue(self):
         while True:


### PR DESCRIPTION
## Summary
- ensure audio buffers aren't overwritten before they're processed

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_683f92febe38832387e1b69d5dad8e30