### PR TITLE
Add unit tests for audio processing

### DIFF
--- a/tests/test_audio_processing.py
+++ b/tests/test_audio_processing.py
@@ -1,0 +1,17 @@
+import sys, os; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import numpy as np
+import audio_processing
+
+
+def test_apply_3d_surround_length():
+    samples = np.tile(np.array([1000, -1000], dtype=np.int16), 44100)
+    output = audio_processing.apply_3d_surround(samples, 44100)
+    assert len(output) == len(samples)
+    assert not np.array_equal(output, samples)
+
+
+def test_process_audio_surround():
+    samples = np.tile(np.array([1000, -1000], dtype=np.int16), 44100)
+    output = audio_processing.process_audio(samples, 44100)
+    assert output is not None
+    assert len(output) == len(samples)


### PR DESCRIPTION
## Summary
- add `tests/test_audio_processing.py` for basic coverage of audio functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f935701488323b2074fb7b637fc60