### PR TITLE
Add equalizer and reverb processing

### DIFF
--- a/README
+++ b/README
@@ -10,6 +10,8 @@ The 8D Audio Processor is an application designed to enhance audio experiences b
 - **Customizable Effects**: Adjust panning speed, reverb amount, and equalizer settings.
 - **Theming**: Choose from different themes for the application interface.
 
+The audio engine applies these settings in real time, using a built-in equalizer and simple reverb to enhance playback.
+
 ## Installation
 
 ### Requirements

--- a/app.py
+++ b/app.py
@@ -157,7 +157,8 @@ class MainWindow(QWidget):
             logger.warning(f"Status: {status}")
         pan_speed = self.pan_slider.value() / 100.0
         reverb_amount = self.reverb_slider.value() / 100.0
-        self.audio_processing_queue.add_to_queue(indata, pan_speed, reverb_amount)
+        eq_gains = self.get_eq_gains()
+        self.audio_processing_queue.add_to_queue(indata, pan_speed, reverb_amount, eq_gains)
 
     def start_8d_sound(self):
         if self.audio_thread is None:

--- a/audio_processing.py
+++ b/audio_processing.py
@@ -5,6 +5,47 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
+def apply_equalizer(samples, sample_rate, eq_gains):
+    """Apply a simple 10 band equalizer using FFT."""
+    if eq_gains is None:
+        return samples
+
+    samples_f = samples.astype(np.float32)
+    freq_data = np.fft.rfft(samples_f, axis=0)
+    freqs = np.fft.rfftfreq(samples_f.shape[0], d=1 / sample_rate)
+
+    boundaries = [0, 60, 170, 310, 600, 1000, 3000, 6000, 12000, 14000, 16000, sample_rate / 2]
+
+    for i, gain in enumerate(eq_gains):
+        if i >= len(boundaries) - 1:
+            break
+        idx = np.where((freqs >= boundaries[i]) & (freqs < boundaries[i + 1]))
+        freq_data[idx] *= 10 ** (gain / 20.0)
+
+    processed = np.fft.irfft(freq_data, n=samples_f.shape[0], axis=0)
+    return processed
+
+
+def apply_reverb(samples, sample_rate, amount):
+    """Apply a very basic reverb/echo effect."""
+    if amount <= 0:
+        return samples
+
+    delay_samples = int(0.03 * sample_rate)
+    samples_f = samples.astype(np.float32)
+    output = samples_f.copy()
+
+    for i in range(1, 4):
+        start = delay_samples * i
+        if start >= len(samples_f):
+            break
+        decay = amount / (i + 1)
+        output[start:] += samples_f[:-start] * decay
+
+    output = np.clip(output, -32768, 32767)
+    return output
+
 def apply_3d_surround(samples, sample_rate, segments=16):
     duration_ms = len(samples) * 1000 // sample_rate
     audio_segment = AudioSegment(
@@ -27,10 +68,14 @@ def apply_3d_surround(samples, sample_rate, segments=16):
 
 def process_audio(samples, sample_rate, pan_speed=0.1, reverb_amount=0.3, eq_gains=None, surround=True):
     try:
+        processed = samples
         if surround:
-            samples = apply_3d_surround(samples, sample_rate)
-        # Additional processing like equalizer and reverb can be added here
-        return samples
+            processed = apply_3d_surround(processed, sample_rate)
+
+        processed = apply_equalizer(processed, sample_rate, eq_gains)
+        processed = apply_reverb(processed, sample_rate, reverb_amount)
+
+        return processed.astype(np.int16)
     except Exception as e:
         logger.error(f"Error processing audio: {e}")
         return None

--- a/audio_processing_queue.py
+++ b/audio_processing_queue.py
@@ -14,14 +14,14 @@ class AudioProcessingQueue:
         self.thread.daemon = True
         self.thread.start()
 
-    def add_to_queue(self, indata, pan_speed, reverb_amount):
-        self.queue.put((indata, pan_speed, reverb_amount))
+    def add_to_queue(self, indata, pan_speed, reverb_amount, eq_gains):
+        self.queue.put((indata, pan_speed, reverb_amount, eq_gains))
 
     def process_queue(self):
         while True:
-            indata, pan_speed, reverb_amount = self.queue.get()
+            indata, pan_speed, reverb_amount, eq_gains = self.queue.get()
             try:
-                processed_data = process_audio(indata, self.sample_rate, pan_speed, reverb_amount)
+                processed_data = process_audio(indata, self.sample_rate, pan_speed, reverb_amount, eq_gains)
                 if processed_data is not None:
                     sd.play(processed_data, samplerate=self.sample_rate)
             except Exception as e:


### PR DESCRIPTION
## Summary
- pass equalizer gains from the UI to the processing queue
- extend `AudioProcessingQueue` to forward EQ gains
- implement simple FFT-based EQ and echo-like reverb
- document the new audio processing behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f93892bb483238af4312753adbe21